### PR TITLE
Verify: DM the user on SMTP error

### DIFF
--- a/verify/lang/cs.ini
+++ b/verify/lang/cs.ini
@@ -86,3 +86,8 @@ html =
 		</p>
 	</div>
 	</body>
+
+[_post_verify]
+error =
+	Ověřovací kód se mi poslat nepodařilo, nejspíš je v něm chyba: `((address))`. Před požádáním o nový ověřovací kód zavolej příkaz `((prefix))strip`.
+	Pokud je to tvá e-mailová adresa a jde o chybu, kontaktuj někoho z moderátorů.

--- a/verify/lang/en.ini
+++ b/verify/lang/en.ini
@@ -79,3 +79,9 @@ html =
 		</p>
 	</div>
 	</body>
+
+[_post_verify]
+error = . If that's your mail, contact someone from the moderator team.
+error =
+	I could not send the verification code, you've probably made a typo: `((address))`. Invoke the command `((prefix))strip` before requesting new code.
+	If I'm wrong and the e-mail is correct, contact someone from the moderator team.

--- a/verify/module.py
+++ b/verify/module.py
@@ -176,13 +176,15 @@ class Verify(commands.Cog):
             delete_after=120,
         )
 
-        await self.post_verify(ctx)
+        await self.post_verify(ctx, address)
 
-    async def post_verify(self, ctx):
+    async def post_verify(self, ctx, address: str):
         """Wait some time after the user requested verification code.
 
         Then connect to IMAP server and check for possilibity that they used
         wrong, invalid e-mail. If such e-mails are found, they will be logged.
+
+        :param address: User's e-mail address.
         """
         # TODO Use embeds when we support them.
         await asyncio.sleep(20)
@@ -194,11 +196,19 @@ class Verify(commands.Cog):
             await guild_log.warning(
                 user,
                 channel,
-                (
-                    "Could not deliver verification code: "
-                    f"{message['subject']} (User ID {message['user']})",
-                ),
+                "Could not deliver verification code: "
+                f"{message['subject']} (User ID {message['user']})",
             )
+            with contextlib.suppress(discord.Forbidden):
+                await ctx.author.send(
+                    tr(
+                        "_post_verify",
+                        "error",
+                        ctx,
+                        address=address,
+                        prefix=config.prefix,
+                    )
+                )
 
     @commands.guild_only()
     @commands.check(check.acl)


### PR DESCRIPTION
The error message has only been announced as log event. Now a DM will be
sent to the user, notifying them about possible typo.