### PR TITLE
Fixed rwhois for disconnected member

### DIFF
--- a/whois/module.py
+++ b/whois/module.py
@@ -124,9 +124,6 @@ class Whois(commands.Cog):
             return
 
         dc_member = ctx.guild.get_member(db_member.user_id)
-        if dc_member is None:
-            await ctx.reply(_(ctx, "Member is not on this server."))
-            return
 
         await self._whois_reply(ctx, db_member, dc_member)
         await guild_log.info(


### PR DESCRIPTION
It's not necessary to check if dc_member is None (is connected), 'cause if he's not, it's still possible to show his info.