### PR TITLE
Make verify address domain case insensitive

### DIFF
--- a/verify/module.py
+++ b/verify/module.py
@@ -77,12 +77,12 @@ class Verify(commands.Cog):
             )
             return
 
-        """Convert address domain to lower-case (make it case-insensitive)"""
-        domainRegex = r"([^@]+$)"
-        domain = re.search(domainRegex, address)
+        # Convert address domain to lower-case (make it case-insensitive)
+        domain_regex  = r"([^@]+$)"
+        domain = re.search(domain_regex , address)
         
         if domain is not None:
-            address = re.sub(domainRegex, domain.group(0).lower(), address)
+            address = re.sub(domain_regex, domain.group(0).lower(), address)
         
         groups: List[VerifyGroup] = self._map_address_to_groups(
             ctx.guild.id, ctx.author.id, address, include_wildcard=False


### PR DESCRIPTION
After a quick chat on FSI Discord I decided to make fix for domain names case sensitivity by findig domain by using regex and then converting to lower case.