### PR TITLE
Unverify: Fix logging problems

### DIFF
--- a/po/cs.popie
+++ b/po/cs.popie
@@ -85,59 +85,8 @@ msgstr Tento server nemá žádný satelitní mapping.
 msgid Satellite has been deconstructed.
 msgstr Satelit byl odebrán.
 
-msgid Reverify failed: Member ({user_id}) was not found. Setting status to `member left server`.
-msgstr Reverifikace selhala: Člen ({user_id}) nebyl nalezen. Nastavuji jeho status na `member left server`
-
-msgid Returning role {role_name} to {member_name} ({member_id}) failed. Insufficient permissions.
-msgstr Vrácení role {role_name} uživateli {member_name} ({member_id}) selhalo. Nedostatečná oprávnění.
-
-msgid Role with ID {role_id} could not be found.
-msgstr Role s ID {role_id} nebyla nalezena.
-
-msgid Could not add {member_name} ({member_id}) to {channel_name}. Insufficient permissions.
-msgstr Není možné přiřadit {member_name} ({member_id}) do kanálu {channel_name}. Nedostatečná oprávnění.
-
-msgid Could not add {member_name} ({member_id}) to channel ({channel_id}). Channel doesn't exist.
-msgstr Není možné přiřadit {member_name} ({member_id}) do kanálu {channel_name}. Kanál neexistuje.
-
-msgid Could not remove {member_name} ({member_id}) from {channel_name}. Insufficient permissions.
-msgstr Není možné odebrat {member_name} ({member_id}) z kanálu {channel_name}. Nedostatečná oprávnění.
-
-msgid Could not remove {member_name} ({member_id}) from channel ({channel_id}). Channel doesn't exist.
-msgstr Není možné přiřadit {member_name} ({member_id}) do kanálu {channel_name}. Kanál neexistuje.
-
-msgid Reverifying {member_name} ({member_id}).
-msgstr Reverifikace uživatele {member_name} ({member_id}).
-
-msgid Removing unverify role from  {member_name} ({member_id}) failed. Insufficient permissions.
-msgstr Odebrání unverify role uživateli {member_name} ({member_id}) selhalo. Nedostatečná oprávnění.
-
-msgid Removing unverify role from  {member_name} ({member_id}) failed. Role not found.
-msgstr Odebrání unverify role uživateli {member_name} ({member_id}) selhalo. Role neexistuje.
-
-msgid Reverify success for member {member_name}.
-msgstr Reverifikace uživatele {member_name} byla úspěšná.
-
 msgid Your access to the guild **{guild_name}** was returned.
 msgstr Tvoje oprávnění k serveru **{guild_name}** bylo navráceno.
-
-msgid Couldn't send reverify info to {member_name}'s DM
-msgstr Nebylo možné poslat uživateli {member_name} do DM informace o reverifikaci.
-
-msgid Removing role {role_name} from  {member_name} ({member_id}) failed. Insufficient permissions.
-msgstr Odebrání role {role_name} uživateli {member_name} ({member_id}) selhalo. Nedostatečná oprávnění.
-
-msgid Adding unverify role to {member_name} ({member_id}) failed. Insufficient permissions.
-msgstr Přidání unverify role uživateli {member_name} ({member_id}) selhalo. Nedostatečná oprávnění.
-
-msgid Adding unverify role to {member_name} ({member_id}) failed. Role not found.
-msgstr Přidání unverify role uživateli {member_name} ({member_id}) selhalo. Role neexistuje.
-
-msgid Adding temp permissions for {member_name} ({member_id}) to {channel_name} failed. Insufficient permissions.
-msgstr Přidání dočasných oprávnění uživateli {member_name} ({member_id}) do kanálu {channel_name} selhalo. Nedostatečná oprávnění.
-
-msgid Removing {member_name} ({member_id}) from {channel_name} failed. Insufficient permissions.
-msgstr Odebrání uživatele {member_name} ({member_id}) z kanálu {channel_name} selhalo. Nedostatečná oprávnění
 
 msgid Unverify role was set to {role_name}.
 msgstr Unverify role byla nastavena na {role_name}.
@@ -163,14 +112,8 @@ msgstr Důvod
 msgid Member {member_name} was temporarily unverified. The access will be returned on: {end_time}
 msgstr Uživateli {member_name} byla dočasně odebrána práva na server. Navrácena budou: {end_time}
 
-msgid Member {member_name} ({member_id}) unverified: Until - {end_time}, reason - {reason}, type - {type}
-msgstr Uživatel {member_name} ({member_id}) unverifikován: Do - {end_time}, důvod - {reason}, typ - {type}
-
 msgid Is this member really unverified?
 msgstr Je tento uživatel opravdu unverifikován?
-
-msgid Unverify of {member_name} ({member_id}) was pardoned.
-msgstr Unverifikace {member_name} ({member_id}) byla prominuta.
 
 msgid Unverify of {member_name} ({member_id}) was pardoned. Access will be returned next time the reverifier loop runs.
 msgstr Unverifikace {member_name} ({member_id}) byla prominuta. Přístup bude navrácen při příštím běhu reverify.
@@ -201,9 +144,6 @@ msgstr Role k navrácení
 
 msgid Channels to return
 msgstr Kanály k navrácení
-
-msgid Member {member_name} ({member_id}) unverified: Until - {end_time}, type - {type}
-msgstr Uživatel {member_name} ({member_id}) unverifikován: Do - {end_time}, typ - {type}
 
 msgid {mention} You have to include your e-mail.
 msgstr {mention} Musíš přiložit svůj e-mail.

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -85,58 +85,7 @@ msgstr
 msgid Satellite has been deconstructed.
 msgstr
 
-msgid Reverify failed: Member ({user_id}) was not found. Setting status to `member left server`.
-msgstr
-
-msgid Returning role {role_name} to {member_name} ({member_id}) failed. Insufficient permissions.
-msgstr
-
-msgid Role with ID {role_id} could not be found.
-msgstr
-
-msgid Could not add {member_name} ({member_id}) to {channel_name}. Insufficient permissions.
-msgstr
-
-msgid Could not add {member_name} ({member_id}) to channel ({channel_id}). Channel doesn't exist.
-msgstr
-
-msgid Could not remove {member_name} ({member_id}) from {channel_name}. Insufficient permissions.
-msgstr
-
-msgid Could not remove {member_name} ({member_id}) from channel ({channel_id}). Channel doesn't exist.
-msgstr
-
-msgid Reverifying {member_name} ({member_id}).
-msgstr
-
-msgid Removing unverify role from  {member_name} ({member_id}) failed. Insufficient permissions.
-msgstr
-
-msgid Removing unverify role from  {member_name} ({member_id}) failed. Role not found.
-msgstr
-
-msgid Reverify success for member {member_name}.
-msgstr
-
 msgid Your access to the guild **{guild_name}** was returned.
-msgstr
-
-msgid Couldn't send reverify info to {member_name}'s DM
-msgstr
-
-msgid Removing role {role_name} from  {member_name} ({member_id}) failed. Insufficient permissions.
-msgstr
-
-msgid Adding unverify role to {member_name} ({member_id}) failed. Insufficient permissions.
-msgstr
-
-msgid Adding unverify role to {member_name} ({member_id}) failed. Role not found.
-msgstr
-
-msgid Adding temp permissions for {member_name} ({member_id}) to {channel_name} failed. Insufficient permissions.
-msgstr
-
-msgid Removing {member_name} ({member_id}) from {channel_name} failed. Insufficient permissions.
 msgstr
 
 msgid Unverify role was set to {role_name}.
@@ -163,13 +112,7 @@ msgstr
 msgid Member {member_name} was temporarily unverified. The access will be returned on: {end_time}
 msgstr
 
-msgid Member {member_name} ({member_id}) unverified: Until - {end_time}, reason - {reason}, type - {type}
-msgstr
-
 msgid Is this member really unverified?
-msgstr
-
-msgid Unverify of {member_name} ({member_id}) was pardoned.
 msgstr
 
 msgid Unverify of {member_name} ({member_id}) was pardoned. Access will be returned next time the reverifier loop runs.
@@ -200,9 +143,6 @@ msgid Roles to return
 msgstr
 
 msgid Channels to return
-msgstr
-
-msgid Member {member_name} ({member_id}) unverified: Until - {end_time}, type - {type}
 msgstr
 
 msgid {mention} You have to include your e-mail.

--- a/unverify/module.py
+++ b/unverify/module.py
@@ -59,7 +59,8 @@ class Unverify(commands.Cog):
                 await bot_log.warning(
                     None,
                     None,
-                    f"Reverify failed: Guild ({item.guild_id}) was not found.\nSetting status to `guild could not be found`",
+                    f"Reverify failed: Guild ({item.guild_id}) was not found. "
+                    + "Setting status to `guild could not be found`",
                 )
                 item.status = UnverifyStatus.guild_not_found
             item.last_check = datetime.now()
@@ -84,7 +85,8 @@ class Unverify(commands.Cog):
                     await guild_log.warning(
                         None,
                         guild,
-                        f"Reverify failed: Member ({item.user_id}) was not found. Setting status to `member left server`.",
+                        f"Reverify failed: Member ({item.user_id}) was not found. "
+                        + "Setting status to `member left server`.",
                     )
                     item.status = UnverifyStatus.member_left
                     item.save()
@@ -104,7 +106,8 @@ class Unverify(commands.Cog):
                     await guild_log.warning(
                         None,
                         member.guild,
-                        f"Returning role {role.name} to {member.name} ({member.id}) failed. Insufficient permissions.",
+                        f"Returning role {role.name} to {member.name} ({member.id}) failed. "
+                        + "Insufficient permissions.",
                     )
             else:
                 await guild_log.warning(
@@ -127,13 +130,15 @@ class Unverify(commands.Cog):
                     await guild_log.warning(
                         None,
                         member.guild,
-                        f"Could not add {member.name} ({member.id}) to {channel.name}. Insufficient permissions.",
+                        f"Could not add {member.name} ({member.id}) to {channel.name}. "
+                        + "Insufficient permissions.",
                     )
             else:
                 await guild_log.warning(
                     None,
                     member.guild,
-                    f"Could not add {member.name} ({member.id}) to {channel.name}. Channel doesn't exist.",
+                    f"Could not add {member.name} ({member.id}) to {channel.name}. "
+                    + "Channel doesn't exist.",
                 )
 
     @staticmethod
@@ -150,13 +155,15 @@ class Unverify(commands.Cog):
                     await guild_log.warning(
                         None,
                         member.guild,
-                        f"Could not remove {member.name} ({member.id}) from {channel.name}. Insufficient permissions.",
+                        f"Could not remove {member.name} ({member.id}) "
+                        + f"from {channel.name}. Insufficient permissions.",
                     )
             else:
                 await guild_log.warning(
                     None,
                     member.guild,
-                    f"Could not remove {member.name} ({member.id}) from channel ({channel.id}). Channel doesn't exist.",
+                    f"Could not remove {member.name} ({member.id}) "
+                    + f"from channel ({channel.id}). Channel doesn't exist.",
                 )
 
     async def _reverify_user(self, item: UnverifyItem):
@@ -189,13 +196,15 @@ class Unverify(commands.Cog):
                 await guild_log.warning(
                     None,
                     member.guild,
-                    f"Removing unverify role from  {member.name} ({member.id}) failed. Insufficient permissions.",
+                    f"Removing unverify role from  {member.name} ({member.id}) failed. "
+                    + "Insufficient permissions.",
                 )
         else:
             await guild_log.warning(
                 None,
                 member.guild,
-                f"Removing unverify role from  {member.name} ({member.id}) failed. Role not found.",
+                f"Removing unverify role from  {member.name} ({member.id}) failed. "
+                + "Role not found.",
             )
 
         utx = i18n.TranslationContext(guild.id, member.id)
@@ -225,13 +234,14 @@ class Unverify(commands.Cog):
                 await member.remove_roles(role, reason=type.value, atomic=True)
                 removed_roles.append(role)
             except NotFound:
-                # This could be deleted roles just moment after the unverify started of someone tried to unverify a bot.
+                # The role got deleted or someone tried to unverify a bot.
                 pass
             except nextcord.errors.Forbidden:
                 await guild_log.warning(
                     None,
                     member.guild,
-                    f"Removing role {role.name} from  {member.name} ({member.id}) failed. Insufficient permissions.",
+                    f"Removing role {role.name} from  {member.name} ({member.id}) failed. "
+                    + "Insufficient permissions.",
                 )
 
         config = GuildConfig.get(guild.id)
@@ -243,7 +253,8 @@ class Unverify(commands.Cog):
                 await guild_log.warning(
                     None,
                     member.guild,
-                    f"Adding unverify role to {member.name} ({member.id}) failed. Insufficient permissions.",
+                    f"Adding unverify role to {member.name} ({member.id}) failed. "
+                    + "Insufficient permissions.",
                 )
         else:
             await guild_log.warning(
@@ -284,7 +295,8 @@ class Unverify(commands.Cog):
                         await guild_log.warning(
                             None,
                             member.guild,
-                            f"Adding temp permissions for {member.name} ({member.id}) to {channel.name} failed. Insufficient permissions.",
+                            f"Adding temp permissions for {member.name} ({member.id}) "
+                            + f"to {channel.name} failed. Insufficient permissions.",
                         )
 
             elif perms.read_messages and not user_overw.read_messages:
@@ -302,7 +314,8 @@ class Unverify(commands.Cog):
                     await guild_log.warning(
                         None,
                         member.guild,
-                        f"Removing {member.name} ({member.id}) from {channel.name} failed. Insufficient permissions.",
+                        f"Removing {member.name} ({member.id}) from {channel.name} failed. "
+                        + "Insufficient permissions.",
                     )
         return removed_channels, added_channels
 
@@ -452,7 +465,10 @@ class Unverify(commands.Cog):
         await ctx.reply(
             _(
                 ctx,
-                "Member {member_name} was temporarily unverified. The access will be returned on: {end_time}",
+                (
+                    "Member {member_name} was temporarily unverified. "
+                    "The access will be returned on: {end_time}"
+                ),
             ).format(
                 member_name=member.name,
                 end_time=end_time_str,
@@ -460,9 +476,10 @@ class Unverify(commands.Cog):
         )
 
         await guild_log.info(
-            ctx.message.author,
+            member,
             ctx.channel,
-            f"Member {member.name} ({member.id}) unverified: Until - {end_time_str}, reason - {reason}, type - {UnverifyType.unverify.value}",
+            f"Member {member.name} ({member.id}) unverified "
+            + f"until {end_time_str}, type {UnverifyType.selfunverify.value}",
         )
 
     @commands.guild_only()
@@ -485,12 +502,15 @@ class Unverify(commands.Cog):
         await guild_log.info(
             ctx.author,
             ctx.channel,
-            "Unverify of {member.name} ({member.id}) was pardoned.",
+            f"Unverify of {member.name} ({member.id}) was pardoned.",
         )
         await ctx.reply(
             _(
                 ctx,
-                "Unverify of {member_name} ({member_id}) was pardoned. Access will be returned next time the reverifier loop runs.",
+                (
+                    "Unverify of {member_name} ({member_id}) was pardoned. "
+                    "Access will be returned next time the reverifier loop runs."
+                ),
             ).format(
                 member_name=member.name,
                 member_id=member.id,
@@ -649,7 +669,10 @@ class Unverify(commands.Cog):
         await ctx.reply(
             _(
                 ctx,
-                "Member {member_name} was temporarily unverified. The access will be returned on: {end_time}",
+                (
+                    "Member {member_name} was temporarily unverified. "
+                    "The access will be returned on: {end_time}"
+                ),
             ).format(
                 member_name=ctx.message.author.name,
                 end_time=end_time_str,
@@ -660,7 +683,8 @@ class Unverify(commands.Cog):
         await guild_log.info(
             member,
             ctx.channel,
-            f"Member {member.name} ({member.id}) unverified: Until - {end_time_str}, type - {UnverifyType.selfunverify.value}",
+            f"Member {member.name} ({member.id}) unverified "
+            + f"until {end_time_str}, type {UnverifyType.selfunverify.value}",
         )
 
     @commands.guild_only()
@@ -716,7 +740,10 @@ class Unverify(commands.Cog):
         await ctx.reply(
             _(
                 ctx,
-                "Member {member_name} was temporarily unverified. The access will be returned on: {end_time}",
+                (
+                    "Member {member_name} was temporarily unverified. "
+                    "The access will be returned on: {end_time}"
+                ),
             ).format(
                 member_name=ctx.message.author.name,
                 end_time=end_time_str,
@@ -727,7 +754,8 @@ class Unverify(commands.Cog):
         await guild_log.info(
             member,
             ctx.channel,
-            f"Member {member.name} ({member.id}) unverified: Until - {end_time_str}, type - {UnverifyType.selfunverify.valu}",
+            f"Member {member.name} ({member.id}) unverified "
+            + f"until {end_time_str}, type {UnverifyType.selfunverify.value}",
         )
 
 


### PR DESCRIPTION
- In 'gn', f-string was accessing 'UnverifyType.selfunverify.valu'
  instead of 'UnverifyType.selfunverify.value'
- String were updated to stay under 100 character limit
- Excessive strings were removed from PoPie files, as log messages
  are no longer translated.