### PR TITLE
Verify: Disable log messages tag sanitisation

### DIFF
--- a/verify/module.py
+++ b/verify/module.py
@@ -105,7 +105,7 @@ class Verify(commands.Cog):
                 ctx.channel,
                 (
                     "Attempted to verify with ID already in database: "
-                    f"'{utils.text.sanitise(address)}'."
+                    f"'{utils.text.sanitise(address, tag_escape=False)}'."
                 ),
             )
             await ctx.send(
@@ -126,7 +126,7 @@ class Verify(commands.Cog):
                 ctx.channel,
                 (
                     "Attempted to verify with address already in database: "
-                    f"'{utils.text.sanitise(address)}'."
+                    f"'{utils.text.sanitise(address, tag_escape=False)}'."
                 ),
             )
             await ctx.send(


### PR DESCRIPTION
It's not necessary to sanitise tags in log message since these are logged in \`\`\`message\`\`\` blocks. This causes issue when using coppied mail in !rwhois command since there is ZERO_WIDTH_SPACE