### PR TITLE
Verify: Provide better log information for existing e-mail address

### DIFF
--- a/po/cs.popie
+++ b/po/cs.popie
@@ -151,8 +151,11 @@ msgstr {mention} Ke zprávě musíš přiložit svůj e-mail.
 msgid {mention} This e-mail cannot be used.
 msgstr {mention} Tento e-mail nejde použít.
 
-msgid {mention} You are already in the database. Contact the moderator team.
-msgstr {mention} Už jsi v databázi. Kontaktuj moderátory.
+msgid {mention} Your user account is already in the database. Check the e-mail inbox or contact the moderator team.
+msgstr {mention} Tvůj uživatelský účet už v databázi existuje. Zkontroluj inbox e-mailu nebo kontaktuj moderátory.
+
+msgid {mention} This e-mail is already in the database registered under different user account. Login with that account and/or contact the moderator team.
+msgstr {mention} Tento e-mail je už registrovaný jiným uživatelským účtem. Přihlas se jím a/nebo kontaktuj moderátory.
 
 msgid {mention} An error has occured while sending the code. Contact the moderator team.
 msgstr {mention} Při posílání kódu nastala chyba. Kontaktuj moderátory.

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -151,8 +151,11 @@ msgstr {mention} Musíš priložiť svoj email.
 msgid {mention} This e-mail cannot be used.
 msgstr Tento email sa nedá použiť.
 
-msgid {mention} You are already in the database. Contact the moderator team.
-msgstr {mention} Už si v databáze. Kontaktuj moderátorov.
+msgid {mention} Your user account is already in the database. Check the e-mail inbox or contact the moderator team.
+msgstr {mention} Tvůj užívateľský účet už v databázi existuje. Skontroluj e-mailovú schránku alebo kontaktuj moderátorov.
+
+msgid {mention} This e-mail is already in the database registered under different user account. Login with that account and/or contact the moderator team.
+msgstr {mention} Tento e-mail je už zaregistrovaný na inom užívateľskom účte. Prihlas sa jím a/alebo kontaktuj moderátorov.
 
 msgid {mention} An error has occured while sending the code. Contact the moderator team.
 msgstr {mention} Pri posielaní kódu nastala chyba. Kontaktuj moderátorov.


### PR DESCRIPTION
Previously only generic 'Attempted to verify with address already in
database' message was being logged, which does not provide all the
information.

Now the log will say if it's them or some other user who has used the
address.

User-facing message stays the same to prevent information leakage.