### PR TITLE
Unverify: Fix logging of unverify

### DIFF
--- a/unverify/module.py
+++ b/unverify/module.py
@@ -481,7 +481,7 @@ class Unverify(commands.Cog):
             member,
             ctx.channel,
             f"Member {member.name} ({member.id}) unverified "
-            + f"until {end_time_str}, type {UnverifyType.selfunverify.value}",
+            + f"until {end_time_str}, type {UnverifyType.unverify.value}",
         )
 
     @commands.guild_only()


### PR DESCRIPTION
Module was logging unverify command invoked by admin as self unverify. Fixed now.