### PR TITLE
Verify: Change order of checks for 'verify' command

### DIFF
--- a/po/cs.popie
+++ b/po/cs.popie
@@ -259,11 +259,11 @@ msgstr Kanály k navrácení
 msgid {mention} You have to include your e-mail.
 msgstr {mention} Ke zprávě musíš přiložit svůj e-mail.
 
-msgid {mention} This e-mail cannot be used.
-msgstr {mention} Tento e-mail nejde použít.
-
 msgid {mention} Your user account is already in the database. Check the e-mail inbox or contact the moderator team.
 msgstr {mention} Tvůj uživatelský účet už v databázi existuje. Zkontroluj inbox e-mailu nebo kontaktuj moderátory.
+
+msgid {mention} This e-mail cannot be used.
+msgstr {mention} Tento e-mail nejde použít.
 
 msgid {mention} This e-mail is already in the database registered under different user account. Login with that account and/or contact the moderator team.
 msgstr {mention} Tento e-mail je už registrovaný jiným uživatelským účtem. Přihlas se jím a/nebo kontaktuj moderátory.

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -259,11 +259,11 @@ msgstr Kanály na vrátenie
 msgid {mention} You have to include your e-mail.
 msgstr {mention} Musíš priložiť svoj email.
 
-msgid {mention} This e-mail cannot be used.
-msgstr {mention} Tento email sa nedá použiť.
-
 msgid {mention} Your user account is already in the database. Check the e-mail inbox or contact the moderator team.
 msgstr {mention} Tvůj užívateľský účet už v databázi existuje. Skontroluj e-mailovú schránku alebo kontaktuj moderátorov.
+
+msgid {mention} This e-mail cannot be used.
+msgstr {mention} Tento email sa nedá použiť.
 
 msgid {mention} This e-mail is already in the database registered under different user account. Login with that account and/or contact the moderator team.
 msgstr {mention} Tento e-mail je už zaregistrovaný na inom užívateľskom účte. Prihlas sa jím a/alebo kontaktuj moderátorov.

--- a/verify/module.py
+++ b/verify/module.py
@@ -79,6 +79,27 @@ class Verify(commands.Cog):
             )
             return
 
+        if VerifyMember.get_by_member(ctx.guild.id, ctx.author.id) is not None:
+            await guild_log.debug(
+                ctx.author,
+                ctx.channel,
+                (
+                    "Attempted to verify with ID already in database: "
+                    f"'{utils.text.sanitise(address, tag_escape=False)}'."
+                ),
+            )
+            await ctx.send(
+                _(
+                    ctx,
+                    (
+                        "{mention} Your user account is already in the database. "
+                        "Check the e-mail inbox or contact the moderator team."
+                    ),
+                ).format(mention=ctx.author.mention),
+                delete_after=120,
+            )
+            return
+
         # Make the address domain case insensitive
         domain_regex: str = r"([^@]+$)"
         domain = re.search(domain_regex, address)
@@ -98,27 +119,6 @@ class Verify(commands.Cog):
                 _(ctx, "{mention} This e-mail cannot be used.").format(
                     mention=ctx.author.mention
                 ),
-                delete_after=120,
-            )
-            return
-
-        if VerifyMember.get_by_member(ctx.guild.id, ctx.author.id) is not None:
-            await guild_log.info(
-                ctx.author,
-                ctx.channel,
-                (
-                    "Attempted to verify with ID already in database: "
-                    f"'{utils.text.sanitise(address, tag_escape=False)}'."
-                ),
-            )
-            await ctx.send(
-                _(
-                    ctx,
-                    (
-                        "{mention} Your user account is already in the database. "
-                        "Check the e-mail inbox or contact the moderator team."
-                    ),
-                ).format(mention=ctx.author.mention),
                 delete_after=120,
             )
             return

--- a/verify/module.py
+++ b/verify/module.py
@@ -337,7 +337,7 @@ class Verify(commands.Cog):
         db_member.status = VerifyStatus.VERIFIED.value
         db_member.save()
 
-        await guild_log.info(ctx.author, ctx.channel, "Verification sucessfull.")
+        await guild_log.info(ctx.author, ctx.channel, "Verification successfull.")
 
         await self._add_roles(ctx.author, db_member)
 


### PR DESCRIPTION
Move verification detection to earlier place in the list of checks, so
users don't struggle with bad e-mail formats before they find out they
really should check their inbox.

Also decreased the log level do debug, guild moderators don't need to
know about these attempts.