### PR TITLE
Unverify: check for hierarchy

### DIFF
--- a/po/cs.popie
+++ b/po/cs.popie
@@ -205,6 +205,9 @@ msgstr Unverify není nastavena.
 msgid Unverify config is not set for this guild. The administrators need to fix this.
 msgstr Unverify není nastavena pro tento server. Jeho administrátoři to musí opravit.
 
+msgid Cannot unverify member with higher or equal role!
+msgstr Nelze dát unverify členovi s vyšší nebo stejnou rolí!
+
 msgid I don't know how to parse `{datetime_str}`, please try again.
 msgstr Nevím jak přečíst `{datetime_str}`, zkus to znovu.
 

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -205,6 +205,9 @@ msgstr Unverify rola nie je nastavená.
 msgid Unverify config is not set for this guild. The administrators need to fix this.
 msgstr Unverify konfigurácia nie je nastavená pre tento server. Toto musia opraviť administrátori.
 
+msgid Cannot unverify member with higher or equal role!
+msgstr
+
 msgid I don't know how to parse `{datetime_str}`, please try again.
 msgstr Neviem ako prečítať `{datetime_str}`, prosím skús to znova.
 

--- a/unverify/module.py
+++ b/unverify/module.py
@@ -12,7 +12,7 @@ from discord import Guild, Member
 from discord.errors import NotFound
 from discord.ext import commands, tasks
 from discord.ext.commands.bot import Bot
-from pie import check, i18n, logger, utils
+from pie import check, i18n, logger, utils, acl
 
 from .database import UnverifyGuildConfig, UnverifyItem, UnverifyStatus, UnverifyType
 
@@ -436,6 +436,11 @@ class Unverify(commands.Cog):
                     "Unverify config is not set for this guild. The administrators need to fix this.",
                 )
             )
+            return
+        banner_acl_level = acl.map_member_to_ACLevel(bot=self.bot, member=ctx.author)
+        banned_acl_level = acl.map_member_to_ACLevel(bot=self.bot, member=member)
+        if banned_acl_level >= banner_acl_level:
+            await ctx.reply(_(ctx, "Cannot unverify member with higher or equal role!"))
             return
         try:
             end_time = utils.time.parse_datetime(datetime_str)


### PR DESCRIPTION
Now it is impossible to unverify someone with the same or higher role.
Resolves #55 