### PR TITLE
Verify fix

### DIFF
--- a/verify/database.py
+++ b/verify/database.py
@@ -289,6 +289,7 @@ class VerifyMapping(database.base):
         :param email: Can be used instead of username and domain.
         :return: VerifyMapping if user is mapped, None otherwise
 
+        :raises ValueError: Email is not valid (missing parts)
         """
         if email:
             username, domain = email.rsplit("@", 1)

--- a/verify/module.py
+++ b/verify/module.py
@@ -1158,7 +1158,10 @@ class Verify(commands.Cog):
         :param ctx: Command context
         :param address: Supplied e-mail address
         """
-        mapping = VerifyMapping.map(guild_id=ctx.guild.id, email=address)
+        try:
+            mapping = VerifyMapping.map(guild_id=ctx.guild.id, email=address)
+        except ValueError:
+            mapping = None
 
         if not mapping or not mapping.rule:
             await guild_log.info(


### PR DESCRIPTION
When member used wrong email address with missing @ symbol (e.g. `-verify ThisWontWork`), this error was thrown.

There were two problems - first was that the Map function was missing documentation on error it raises. The second one was that in helper function `_is_supported_address` the error was not handled correctly. In other cases the map function is used on sanitized input or the input is already split and unpacked (safely), so no action is required.

```
Traceback (most recent call last):
  File "/root/.local/lib/python3.10/site-packages/discord/ext/commands/core.py", line 229, in wrapped
    ret = await coro(*args, **kwargs)
  File "/pumpkin-py/modules/mgmt/verify/module.py", line 90, in verify
    if not await self._is_supported_address(ctx, address):
  File "/pumpkin-py/modules/mgmt/verify/module.py", line 1161, in _is_supported_address
    mapping = VerifyMapping.map(guild_id=ctx.guild.id, email=address)
  File "/pumpkin-py/modules/mgmt/verify/database.py", line 294, in map
    username, domain = email.rsplit("@", 1)
ValueError: not enough values to unpack (expected 2, got 1)```