### PR TITLE
Added exception for non existing role in list

### DIFF
--- a/unverify/module.py
+++ b/unverify/module.py
@@ -611,7 +611,10 @@ class Unverify(commands.Cog):
             roles = []
             for role_id in item.roles_to_return:
                 role = discord.utils.get(guild.roles, id=role_id)
+                if role.name is None:
+                    role.name = "Unknown"
                 roles.append(role)
+                
             channels = []
             for channel_id in item.channels_to_return:
                 channel = discord.utils.get(guild.channels, id=channel_id)

--- a/unverify/module.py
+++ b/unverify/module.py
@@ -611,10 +611,10 @@ class Unverify(commands.Cog):
             roles = []
             for role_id in item.roles_to_return:
                 role = discord.utils.get(guild.roles, id=role_id)
-                if role.name is None:
-                    role.name = "Unknown"
+                if role is None:
+                    continue
                 roles.append(role)
-                
+
             channels = []
             for channel_id in item.channels_to_return:
                 channel = discord.utils.get(guild.channels, id=channel_id)


### PR DESCRIPTION
Proposal fix of caused error raised for command, unverify list all:

AttributeError: 'NoneType' object has no attribute 'name' Traceback (most recent call last):
  File "/root/.local/lib/python3.10/site-packages/discord/ext/commands/core.py", line 229, in wrapped
    ret = await coro(*args, **kwargs)
  File "/pumpkin-py/modules/mgmt/unverify/module.py", line 635, in unverify_list
    value=", ".join(role.name for role in roles),
  File "/pumpkin-py/modules/mgmt/unverify/module.py", line 635, in <genexpr>
    value=", ".join(role.name for role in roles),
AttributeError: 'NoneType' object has no attribute 'name'